### PR TITLE
Change inspector toggle from escape to Alt + t

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,13 @@ These will be resolved in upcoming releases.
 
 ## Keyboard Shortcuts
 
-- `Esc` - Close inspector
-- `Shift` + `Esc` - Reopen inspector
-- `Alt` + `[` - Focus inspector
+Current shortcuts (see popup Shortcuts tab):
+
+- `Alt` + `X` – Open extension popup
+- `Alt` + `T` – Toggle Inspector (on/off, restores last non-off mode)
+- `Alt` + `M` – Toggle Mini Mode (when inspector is visible)
+- `Alt` + `[` – Enter / Focus the inspector (moves keyboard focus into the inspector UI)
+- `Esc` – When focus is inside the inspector, return focus to the inspected element (never closes the inspector)
 
 ## Installation
 

--- a/manifest.json
+++ b/manifest.json
@@ -105,6 +105,15 @@
         "default": "Alt+X"
       },
       "description": "Open the Access Nexus popup"
+    },
+    "toggle-inspector": {
+      "suggested_key": {
+        "default": "Alt+T",
+        "mac": "Alt+T",
+        "windows": "Alt+T",
+        "linux": "Alt+T"
+      },
+      "description": "Toggle Nexus Inspector"
     }
   }
 }

--- a/src/components/inspector/inspector-content.js
+++ b/src/components/inspector/inspector-content.js
@@ -20,11 +20,6 @@
   const Templates = {
     // Loading spinner removed to comply with no-animation policy.
 
-    CLOSE_BUTTON_ICON: `
-      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
-        <path d="M12 4L4 12M4 4L12 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="square"/>
-      </svg>
-    `,
 
     ERROR_ICON: `
       <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
@@ -97,20 +92,6 @@
       `;
     },
 
-    /**
-     * Create close button HTML
-     * @returns {string} Close button HTML
-     */
-    createCloseButton() {
-      return `
-  <button class="nexus-accessibility-ui-inspector-close" 
-                aria-label="Close Nexus Inspector" 
-                type="button"
-                tabindex="-1">
-          ${Templates.CLOSE_BUTTON_ICON}
-        </button>
-      `;
-    },
 
     /**
      * Generate screen reader output HTML
@@ -483,7 +464,6 @@
       }
 
       try {
-        const closeButtonHtml = this.createCloseButton();
         const screenReaderSection = this.createScreenReaderSection(info);
 
         // Create inspector body wrapper
@@ -494,7 +474,6 @@
         if (miniMode) {
           // Mini mode: only screen reader output
           inspectorContent = `
-            ${closeButtonHtml}
             ${bodyOpen}
               ${screenReaderSection}
             ${bodyClose}
@@ -503,7 +482,6 @@
           // Full mode: screen reader output + properties
           const propertiesSection = this.createPropertiesSection(info);
           inspectorContent = `
-            ${closeButtonHtml}
             ${bodyOpen}
               ${screenReaderSection}
               ${propertiesSection}

--- a/src/components/inspector/inspector-events.js
+++ b/src/components/inspector/inspector-events.js
@@ -172,16 +172,6 @@
       const srNode = queryRoot.querySelector(
         ".nexus-accessibility-ui-inspector-sr"
       );
-      const closeButton = queryRoot.querySelector(
-        ".nexus-accessibility-ui-inspector-close"
-      );
-
-      if (closeButton) {
-        // Upgrade close control to an accessible button
-        closeButton.setAttribute("role", "button");
-        closeButton.setAttribute("tabindex", "0");
-        closeButton.setAttribute("aria-hidden", "false");
-      }
 
       this.core.inspector.removeAttribute("aria-hidden");
       this.core.focus._acceptingFocus = true;
@@ -203,47 +193,6 @@
       e.stopPropagation();
     }
 
-    /**
-     * Setup close button event handlers
-     * @param {Element} closeButton - Close button element
-     * @param {Function} onClose - Close callback function
-     * @param {Function} enabled - Enabled check function
-     */
-    setupCloseButton(closeButton, onClose, enabled) {
-      if (!closeButton) return;
-
-      // Enhanced close button functionality
-      const handleClose = (e) => {
-        e.preventDefault();
-        try {
-          if (enabled && enabled()) {
-            onClose && onClose();
-          }
-        } catch (error) {
-          console.warn("Error in close handler:", error);
-        }
-      };
-
-      // Handle click events
-      closeButton.addEventListener("click", handleClose);
-
-      // Handle keyboard activation
-      closeButton.addEventListener("keydown", (e) => {
-        if (this._isEnterOrSpace(e)) {
-          e.preventDefault();
-          handleClose(e);
-        }
-      });
-
-      // Prevent mouse events from affecting focus
-      closeButton.addEventListener("mousedown", (e) => {
-        e.preventDefault();
-      });
-
-      closeButton.addEventListener("pointerdown", (e) => {
-        e.preventDefault();
-      });
-    }
 
     /**
      * Check if Enter or Space key was pressed

--- a/src/components/inspector/inspector.css
+++ b/src/components/inspector/inspector.css
@@ -69,28 +69,7 @@
 
 /* Intentionally no animation: inspector appears instantly per updated rules */
 
-/* Close button */
-.nexus-accessibility-ui-inspector-close {
-  position: relative;
-  float: right;
-  margin-right: -2rem;
-  width: 24px;
-  height: 24px;
-  border: none;
-  background: rgba(104, 58, 183, 0.1);
-  color: #683ab7;
-  border-radius: 4px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-}
-
-.nexus-accessibility-ui-inspector-close:hover {
-  background: rgba(104, 58, 183, 0.2);
-  color: #683ab7;
-}
+/* (Close button removed: ESC no longer closes; Alt+T toggles inspector state) */
 
 /* Only show transition for users who don't prefer reduced motion */
 /* Removed transition: Inspector surfaces must not animate (rules §2.7). */

--- a/src/content/content-events.js
+++ b/src/content/content-events.js
@@ -486,15 +486,20 @@
     const inspectorEl = CE.utils.getInspectorElement();
 
     if (e.key === "Escape" && !e.shiftKey) {
-      // If Escape is pressed from within the inspector, let the inspector handle it
+      // New behavior: never close the inspector on plain Escape.
+      // If focus is inside the inspector, move focus back to last inspected element.
       if (inspectorEl && CE.utils.safeContains(inspectorEl, e.target)) {
-        return;
+        const focusState = CE.events.getFocusState ? CE.events.getFocusState() : {};
+        const elToFocus = focusState.inspectedElement || focusState.lastFocusedElement;
+        if (elToFocus && typeof elToFocus.focus === 'function') {
+          try { elToFocus.focus({ preventScroll: false }); } catch(_) {}
+        }
+        e.preventDefault();
+        e.stopPropagation();
+        return; // do nothing else
       }
-
-      // Close inspector and clear state
-      if (CE.inspector) CE.inspector.hideInspector();
-      inspectedElement = null;
-      lastFocusedElement = null;
+      // If focus is outside inspector, ignore (do not close, do not hide).
+      return;
     } else if (e.key === "Escape" && e.shiftKey) {
       // If pressed from within inspector, defer to inspector handler
       if (inspectorEl && CE.utils.safeContains(inspectorEl, e.target)) {

--- a/src/content/content-inspector.js
+++ b/src/content/content-inspector.js
@@ -65,6 +65,7 @@
       );
       return;
     }
+    try { console.log('[ContentExtension.inspector] showInspector invoked (state restore)', { targetTag: target && target.tagName, targetId: target && target.id }); } catch(_) {}
 
     const options = {
       onClose: createCloseHandler(target),
@@ -113,6 +114,7 @@
       window.nexusAccessibilityUiInspector &&
       typeof window.nexusAccessibilityUiInspector.hideInspector === "function"
     ) {
+      try { console.log('[ContentExtension.inspector] hideInspector invoked'); } catch(_) {}
       window.nexusAccessibilityUiInspector.hideInspector(opts);
     } else {
       // Fallback: manually remove inspector

--- a/src/content/content-main.js
+++ b/src/content/content-main.js
@@ -62,7 +62,13 @@
               const current = getInspectorState();
               if (current === 'off') {
                 // Restore last non-off from storage (fallback 'on')
-                const data = await new Promise((resolve)=>{ try { chrome.storage.sync.get({ inspectorPreviousNonOffState: 'on' }, resolve); } catch(e){ resolve({ inspectorPreviousNonOffState:'on'});} });
+                let data;
+                try {
+                  // Use unified promise wrapper
+                  data = await (window.chromeAsync ? window.chromeAsync.storage.sync.get({ inspectorPreviousNonOffState: 'on' }) : new Promise((resolve)=> chrome.storage.sync.get({ inspectorPreviousNonOffState: 'on' }, resolve)));
+                } catch (e) {
+                  data = { inspectorPreviousNonOffState: 'on' };
+                }
                 let restore = data.inspectorPreviousNonOffState || 'on';
                 if (!['on','mini'].includes(restore)) restore = 'on';
                 await new Promise((resolve)=>{ try { chrome.storage.sync.set({ inspectorState: restore }, resolve); } catch(e){ resolve(); } });
@@ -71,7 +77,7 @@
                 // Turning off: capture effective state from storage (authoritative) to avoid race with async mini toggle UI
                 let effectiveState = current;
                 try {
-                  const data = await new Promise((resolve)=>{ try { chrome.storage.sync.get({ inspectorState: current }, resolve); } catch(e){ resolve({ inspectorState: current }); } });
+                  const data = await (window.chromeAsync ? window.chromeAsync.storage.sync.get({ inspectorState: current }) : new Promise((resolve)=> chrome.storage.sync.get({ inspectorState: current }, resolve)));
                   if (data && (data.inspectorState === 'on' || data.inspectorState === 'mini')) {
                     effectiveState = data.inspectorState;
                   }

--- a/src/content/content-main.js
+++ b/src/content/content-main.js
@@ -55,6 +55,35 @@
   chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     try {
       switch (msg.type) {
+        case "COMMAND_TOGGLE_INSPECTOR":
+          // Unified toggle logic matching popup semantics (on/mini -> off, off -> restore previous non-off or on)
+          (async () => {
+            try {
+              const current = getInspectorState();
+              if (current === 'off') {
+                // Restore last non-off from storage (fallback 'on')
+                const data = await new Promise((resolve)=>{ try { chrome.storage.sync.get({ inspectorPreviousNonOffState: 'on' }, resolve); } catch(e){ resolve({ inspectorPreviousNonOffState:'on'});} });
+                let restore = data.inspectorPreviousNonOffState || 'on';
+                if (!['on','mini'].includes(restore)) restore = 'on';
+                await new Promise((resolve)=>{ try { chrome.storage.sync.set({ inspectorState: restore }, resolve); } catch(e){ resolve(); } });
+                updateInspectorState(restore);
+              } else {
+                // Turning off: capture effective state from storage (authoritative) to avoid race with async mini toggle UI
+                let effectiveState = current;
+                try {
+                  const data = await new Promise((resolve)=>{ try { chrome.storage.sync.get({ inspectorState: current }, resolve); } catch(e){ resolve({ inspectorState: current }); } });
+                  if (data && (data.inspectorState === 'on' || data.inspectorState === 'mini')) {
+                    effectiveState = data.inspectorState;
+                  }
+                } catch(_) {}
+                await new Promise((resolve)=>{ try { chrome.storage.sync.set({ inspectorState: 'off', inspectorPreviousNonOffState: effectiveState }, resolve); } catch(e){ resolve(); } });
+                updateInspectorState('off');
+              }
+            } catch (e) {
+              console.warn('[ContentExtension] COMMAND_TOGGLE_INSPECTOR failed', e);
+            }
+          })();
+          break;
         case "INSPECTOR_STATE_CHANGE":
           updateInspectorState(msg.inspectorState);
           break;
@@ -306,6 +335,7 @@
    * Update inspector state across all modules
    */
   function updateInspectorState(state) {
+    const prev = currentInspectorState;
     // Validate state
     const validStates = ["off", "on", "mini"];
     if (!validStates.includes(state)) {
@@ -330,6 +360,59 @@
       CE.inspector.hideInspector();
     } else {
       CE.events.enableEventListeners();
+      // If transitioning from off -> on/mini and inspector not visible, attempt to restore/show
+      try {
+        if (prev === 'off') {
+          const legacy = window.nexusAccessibilityUiInspector;
+          const core = legacy && legacy.core ? legacy.core : null;
+          const focusState = CE.events && typeof CE.events.getFocusState === 'function' ? CE.events.getFocusState() : {};
+          const inspectorHost = CE.inspector && CE.inspector.getInspectorElement ? CE.inspector.getInspectorElement() : null;
+
+          // Resolve a preferred focus candidate: activeElement or lastFocusedElement from events.
+            let candidate = document.activeElement && document.activeElement !== document.body ? document.activeElement : null;
+          if (!candidate && focusState.lastFocusedElement && document.contains(focusState.lastFocusedElement)) {
+            candidate = focusState.lastFocusedElement;
+          }
+          // Ignore candidate if it's inside (or is) the inspector host.
+          if (candidate && inspectorHost) {
+            try {
+              const path = typeof candidate.composedPath === 'function' ? candidate.composedPath() : [];
+              if (path.includes(inspectorHost) || inspectorHost.contains(candidate)) candidate = null;
+            } catch(_) {}
+          }
+
+          const haveCoreRestore = core && core._lastTarget && core._lastInfo && document.contains(core._lastTarget);
+          const needNewFocusInspect = candidate && (!haveCoreRestore || candidate !== core._lastTarget);
+
+          // Helper to perform fresh inspection of candidate
+          const inspectCandidate = (el) => {
+            if (!el || !CE.accessibility || typeof CE.accessibility.getAccessibleInfo !== 'function') return false;
+            try { CE.inspector && CE.inspector.showLoadingInspector && CE.inspector.showLoadingInspector(el); } catch(_) {}
+            CE.accessibility.getAccessibleInfo(el, true)
+              .then(info => {
+                if (!info) { if (haveCoreRestore) { try { CE.inspector.showInspector(core._lastInfo, core._lastTarget, { forceRender: true }); } catch(_) {} } return; }
+                try { if (core) { core._lastTarget = el; core._lastInfo = info; } } catch(_) {}
+                CE.inspector.showInspector(info, el, { forceRender: true });
+              })
+              .catch(err => {
+                console.warn('[ContentExtension] Focus candidate inspect failed; falling back', err);
+                if (haveCoreRestore) { try { CE.inspector.showInspector(core._lastInfo, core._lastTarget, { forceRender: true }); } catch(_) {} }
+              });
+            return true;
+          };
+
+          if (needNewFocusInspect) {
+            inspectCandidate(candidate);
+          } else if (haveCoreRestore) {
+            try { CE.inspector.showInspector(core._lastInfo, core._lastTarget, { forceRender: true }); } catch (e) {}
+          } else if (candidate) {
+            // No previous info but we have a candidate
+            inspectCandidate(candidate);
+          }
+        }
+      } catch (e) {
+        console.warn('[ContentExtension] Toggle restore failed', e);
+      }
     }
 
     // Notify all modules of state change

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -89,15 +89,15 @@
             <h2>Keyboard Shortcuts</h2>
             <dl class="nexus-accessibility-ui-inspector-keys">
               <dt><kbd>Alt</kbd>+<kbd>X</kbd></dt>
-              <dd>Open Nexus panel</dd>
-              <dt><kbd>Esc</kbd></dt>
-              <dd>Close inspector</dd>
-              <dt><kbd>Shift</kbd>+<kbd>Esc</kbd></dt>
-              <dd>Reopen inspector for focused element</dd>
+              <dd>Open Nexus popup</dd>
+              <dt><kbd>Alt</kbd>+<kbd>T</kbd></dt>
+              <dd>Toggle Inspec<strong>t</strong>or</dd>
               <dt><kbd>Alt</kbd>+<kbd>[</kbd></dt>
               <dd>Enter Inspector</dd>
               <dt><kbd>Alt</kbd>+<kbd>M</kbd></dt>
-              <dd>Toggle Mini Mode</dd>
+              <dd>Toggle <strong>M</strong>ini Mode</dd>
+              <dt><kbd>Esc</kbd></dt>
+              <dd>When focus inside Inspector: return focus to inspected element</dd>
             </dl>
           </div>
         </div>

--- a/tests/toggle-shortcut-smoke.js
+++ b/tests/toggle-shortcut-smoke.js
@@ -1,0 +1,58 @@
+// toggle-shortcut-smoke.js
+// Basic smoke assertions for Alt+T (background command toggles inspector state) and ESC behavior.
+// NOTE: This relies on manual triggering of command in Chrome; here we simulate by dispatching the
+// same INSPECTOR_STATE_CHANGE messages the background would send.
+(function () {
+  const LOG_PREFIX = '[SMOKE:toggle-shortcut]';
+  function log(msg, data) { try { console.log(LOG_PREFIX, msg, data||''); } catch(e) {} }
+
+  function sendState(state) {
+    const msg = { type: 'INSPECTOR_STATE_CHANGE', inspectorState: state };
+    window.postMessage({ __nexus_test_forward: true, message: msg }, '*');
+    // Content scripts listen via chrome.runtime messaging; for test harness (in test-runner.html)
+    // ensure a bridge exists to forward these if needed.
+  }
+
+  function assert(cond, label) {
+    if (!cond) {
+      console.error(LOG_PREFIX + ' FAIL:', label);
+    } else {
+      console.log(LOG_PREFIX + ' PASS:', label);
+    }
+  }
+
+  // Sequence: turn on -> verify -> focus inside -> ESC -> verify still open -> turn off
+  setTimeout(() => {
+    sendState('on');
+    setTimeout(() => {
+      const inspector = document.getElementById('nexus-accessibility-ui-inspector') || document.querySelector('.nexus-accessibility-ui-inspector');
+      assert(!!inspector, 'Inspector should be present after state on');
+
+      if (inspector) {
+        // Try to focus first focusable inside shadow if possible
+        try {
+          const shadow = inspector.shadowRoot; // normally closed; fallback to host focus
+          if (shadow) {
+            const focusable = shadow.querySelector('button, [tabindex], input, a, .nexus-accessibility-ui-inspector-sr');
+            if (focusable) focusable.focus(); else inspector.focus();
+          } else {
+            inspector.focus();
+          }
+        } catch (e) { try { inspector.focus(); } catch(_) {} }
+      }
+
+      const escEv = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+      document.dispatchEvent(escEv);
+
+      setTimeout(() => {
+        const stillThere = document.getElementById('nexus-accessibility-ui-inspector') || document.querySelector('.nexus-accessibility-ui-inspector');
+        assert(!!stillThere, 'Inspector should remain after ESC');
+        sendState('off');
+        setTimeout(() => {
+          const gone = document.getElementById('nexus-accessibility-ui-inspector') || document.querySelector('.nexus-accessibility-ui-inspector');
+          assert(!gone, 'Inspector should be removed after state off');
+        }, 150);
+      }, 100);
+    }, 250);
+  }, 500);
+})();


### PR DESCRIPTION
Escape will conflict with many element's open/close behavior. Moved it to a shortcut instead. Users can also toggle visibility using the buttons in the extension popup.